### PR TITLE
[/PAXJDBC-92] - Fix data store password encryption issues

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
@@ -69,12 +69,12 @@ public class DataSourceConfigManager implements ManagedServiceFactory {
             return;
         }
 
-        decryptor.decrypt(config);
+        Dictionary<String, String> decryptedConfig = decryptor.decrypt(config);
 
         try {
-            String filter = getFilter(config);
+            String filter = getFilter(decryptedConfig);
             Filter filterO = context.createFilter(filter);
-            DataSourceFactoryTracker tracker = new DataSourceFactoryTracker(context, filterO, config);
+            DataSourceFactoryTracker tracker = new DataSourceFactoryTracker(context, filterO, config, decryptedConfig);
             tracker.open();
             trackers.put(pid, tracker);
         }

--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceFactoryTracker.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceFactoryTracker.java
@@ -27,17 +27,19 @@ import org.osgi.util.tracker.ServiceTracker;
 @SuppressWarnings("rawtypes")
 final class DataSourceFactoryTracker extends ServiceTracker {
     private Dictionary config;
+    private Dictionary decryptedConfig;
 
-    DataSourceFactoryTracker(BundleContext context, Filter filter, Dictionary config) {
+    DataSourceFactoryTracker(BundleContext context, Filter filter, Dictionary config, Dictionary decryptedConfig) {
         super(context, filter, null);
         this.config = config;
+        this.decryptedConfig = decryptedConfig;
     }
     
     @SuppressWarnings("unchecked")
     @Override
     public Object addingService(ServiceReference reference) {
         DataSourceFactory dsf = (DataSourceFactory) context.getService(reference);
-        return new DataSourceRegistration(context, dsf, config); 
+        return new DataSourceRegistration(context, dsf, config, decryptedConfig);
     }
 
     @Override

--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistration.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistration.java
@@ -60,7 +60,7 @@ public class DataSourceRegistration implements Closeable {
     private AutoCloseable dataSource;
     private ServiceRegistration serviceReg;
 
-    public DataSourceRegistration(BundleContext context, DataSourceFactory dsf, final Dictionary config) {
+    public DataSourceRegistration(BundleContext context, DataSourceFactory dsf, final Dictionary config, final Dictionary decryptedConfig) {
         Object dsName = config.get(DataSourceFactory.JDBC_DATASOURCE_NAME);
         if (dsName != null && config.get(JNDI_SERVICE_NAME) == null) {
             config.put(JNDI_SERVICE_NAME, dsName);
@@ -69,7 +69,7 @@ public class DataSourceRegistration implements Closeable {
         try {
             String typeName = (String)config.get(DATASOURCE_TYPE);
             Class<?> type = getType(typeName);
-            Object ds = createDs(dsf, type, config);
+            Object ds = createDs(dsf, type, decryptedConfig);
             if (ds instanceof AutoCloseable) {
                 dataSource = (AutoCloseable)ds;
             }
@@ -104,10 +104,10 @@ public class DataSourceRegistration implements Closeable {
         }
     }
 
-    private Object createDs(DataSourceFactory dsf, Class<?> type, Dictionary config) throws SQLException {
-        Properties props = toProperties(config);
+    private Object createDs(DataSourceFactory dsf, Class<?> type, Dictionary decryptedConfig) throws SQLException {
+        Properties props = toProperties(decryptedConfig);
         if (type == DataSource.class) {
-            addDataSourceName(dsf, config, props);
+            addDataSourceName(dsf, decryptedConfig, props);
             return dsf.createDataSource(props);
         } else if (type == ConnectionPoolDataSource.class) {
             return dsf.createConnectionPoolDataSource(props);

--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/Decryptor.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/Decryptor.java
@@ -1,9 +1,6 @@
 package org.ops4j.pax.jdbc.config.impl;
 
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.jasypt.encryption.StringEncryptor;
@@ -35,9 +32,9 @@ public class Decryptor {
     }
 
     @SuppressWarnings("rawtypes")
-    public void decrypt(final Dictionary config) {
+    public Dictionary<String, String> decrypt(final Dictionary config) {
         StringEncryptor encryptor = null;
-        Map<String, String> decryptedConfig = new HashMap<String, String>();
+        Dictionary<String, String> decryptedConfig = new Hashtable<String, String>();
         for (Enumeration e = config.keys(); e.hasMoreElements();) {
             final String key = (String) e.nextElement();
             String value = (String) config.get(key);
@@ -55,11 +52,11 @@ public class Decryptor {
                     String plainText = encryptor.decrypt(cipherText);
                     decryptedConfig.put(key, plainText);
                 }
+            } else {
+                decryptedConfig.put(key, value);
             }
         }
-        for (Entry<String, String> entry : decryptedConfig.entrySet()) {
-            config.put(entry.getKey(), entry.getValue());
-        }
+        return decryptedConfig;
     }
 
     public boolean isEncrypted(String value) {

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
@@ -17,6 +17,7 @@
 package org.ops4j.pax.jdbc.config.impl;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyInt;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.matches;
 import static org.easymock.EasyMock.eq;
@@ -170,12 +171,12 @@ public class DataSourceConfigManagerTest {
         Assert.assertEquals("plaintext", (String)properties.get(DataSourceFactory.JDBC_PASSWORD));
     }
 
-    private Decryptor createDecryptor(IMocksControl c) {
+    private Decryptor createDecryptor(IMocksControl c) throws Exception {
         StringEncryptor encryptor = c.createMock(StringEncryptor.class);
         expect(encryptor.decrypt(matches("ciphertext"))).andReturn("plaintext");
 
         ServiceTracker encryptorServiceTracker = c.createMock(ServiceTracker.class);
-        expect(encryptorServiceTracker.getService()).andReturn(encryptor);
+        expect(encryptorServiceTracker.waitForService(anyInt())).andReturn(encryptor);
         Decryptor decryptor = new Decryptor(encryptorServiceTracker);
         return decryptor;
     }

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistrationTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistrationTest.java
@@ -73,7 +73,7 @@ public class DataSourceRegistrationTest {
         properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, H2_DRIVER_CLASS);
         properties.put(DataSourceFactory.JDBC_DATABASE_NAME, "mydbname");
         properties.put(DataSourceFactory.JDBC_DATASOURCE_NAME, "myDsName");
-        DataSourceRegistration publisher = new DataSourceRegistration(context, dsf, properties);
+        DataSourceRegistration publisher = new DataSourceRegistration(context, dsf, properties, properties);
         c.verify();
 
         // Check that correct properties were sent to DataSourceFactory
@@ -121,7 +121,7 @@ public class DataSourceRegistrationTest {
         Dictionary<String, String> properties = new Hashtable<String, String>();
         properties.put(DataSourceRegistration.DATASOURCE_TYPE,
             ConnectionPoolDataSource.class.getSimpleName());
-        DataSourceRegistration publisher = new DataSourceRegistration(context, dsf, properties);
+        DataSourceRegistration publisher = new DataSourceRegistration(context, dsf, properties, properties);
         publisher.close();
         c.verify();
     }
@@ -149,7 +149,7 @@ public class DataSourceRegistrationTest {
         c.replay();
         Dictionary<String, String> properties = new Hashtable<String, String>();
         properties.put(DataSourceRegistration.DATASOURCE_TYPE, XADataSource.class.getSimpleName());
-        new DataSourceRegistration(context, dsf, properties);
+        new DataSourceRegistration(context, dsf, properties, properties);
         c.verify();
     }
 
@@ -165,7 +165,7 @@ public class DataSourceRegistrationTest {
         c.replay();
         Dictionary<String, String> properties = new Hashtable<String, String>();
         properties.put(DataSourceRegistration.DATASOURCE_TYPE, "something else");
-        new DataSourceRegistration(context, dsf, properties);
+        new DataSourceRegistration(context, dsf, properties, properties);
         c.verify();
     }
 


### PR DESCRIPTION
For encryption of the data store password:

1) Currently, it depends on the encryption service being available in the system before this bundle is loaded. It simply loads the decryptor and if the service isn't immediately available it just passes it through as-is. Now, if and only if there is an encrypted value, it waits for the decryptor service to be available before continuing.

2) The decrypted value was visible to the system using a) config:list, and b) the properties of the DataSource service that is exposed. Now it only uses the decrypted configuration for creating the data source, and only the original encrypted value is available via config:list and the service properties.