### PR TITLE
Oracle fix

### DIFF
--- a/pax-jdbc-oracle/src/main/java/org/ops4j/pax/jdbc/oracle/impl/OracleDataSourceFactory.java
+++ b/pax-jdbc-oracle/src/main/java/org/ops4j/pax/jdbc/oracle/impl/OracleDataSourceFactory.java
@@ -100,7 +100,7 @@ public class OracleDataSourceFactory implements DataSourceFactory {
         try {
             ConnectionPoolDataSource ds = ConnectionPoolDataSource.class
                 .cast(oracleConnectionPoolDataSourceClass.newInstance());
-            setProperties(ds, oracleXaDataSourceClass, props);
+            setProperties(ds, oracleConnectionPoolDataSourceClass, props);
             return ds;
         }
         catch (Exception ex) {


### PR DESCRIPTION
The createConnectionPoolDataSource method was passing oracleXaDataSourceClass reference to setProperties method. It should pass oracleConnectionPoolDataSourceClass reference instead. 

Created a jira ticket/issue for the above mentioned issue and this PR contains the fix. Appreciate if you could review and accept the fix. No test cases to update due to dependency on Oracle driver.

Regards,
Pravin