### PR TITLE
[paxjdbc-101] Config: No forward of dataSourceName

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistration.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceRegistration.java
@@ -27,10 +27,7 @@ import javax.sql.DataSource;
 import javax.sql.XADataSource;
 import java.io.Closeable;
 import java.sql.SQLException;
-import java.util.Dictionary;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.Properties;
+import java.util.*;
 
 @SuppressWarnings({
     "rawtypes", "unchecked"
@@ -40,6 +37,13 @@ public class DataSourceRegistration implements Closeable {
     static final String DATASOURCE_TYPE = "dataSourceType";
     static final String JNDI_SERVICE_NAME = "osgi.jndi.service.name";
 
+    // By default all local keys (without a dot) are forwarded to the DataSourceFactory.
+    // These config keys will explicitly not be forwarded to the DataSourceFactory
+    // (even though they are "local" keys without a dot ".")
+    private static final Set<String> NOT_FORWARDED_KEYS = new HashSet<String>(Arrays.asList(new String []{
+            DataSourceFactory.JDBC_DATASOURCE_NAME,
+            DATASOURCE_TYPE
+    }));
     // additionally all keys prefixed with "jdbc." will be forwarded (with the prefix stripped).
     private static final String CONFIG_KEY_PREFIX = "jdbc.";
     
@@ -131,7 +135,7 @@ public class DataSourceRegistration implements Closeable {
             final String unhiddenKey = unhide(originalKey);
             // only forward local configuration keys (i. e. those without a dot)
             // exception: the DATASOURCE_TYPE key (as legacy).
-            if (!unhiddenKey.contains(".") && !DATASOURCE_TYPE.equals(unhiddenKey)) {
+            if (!unhiddenKey.contains(".") && !NOT_FORWARDED_KEYS.contains(unhiddenKey)) {
                 props.put(unhiddenKey, dict.get(originalKey));
             } else if (unhiddenKey.startsWith(CONFIG_KEY_PREFIX)) {
                 props.put(unhiddenKey.substring(CONFIG_KEY_PREFIX.length()), dict.get(originalKey));

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
@@ -206,6 +206,7 @@ public class DataSourceConfigManagerTest {
         final String KEY_HIDDEN_JDBC_PASSWORD = "." + DataSourceFactory.JDBC_PASSWORD;
         final String KEY_NONLOCAL_PROPERTY = "nonlocal.property";
         final String KEY_LOCAL_PROPERTY = "localproperty";
+        final String KEY_DATASOURCE_TYPE = "dataSourceType";
         final String VALUE_LOCAL_PROPERTY = "something2";
         final String dbname = "mydbname";
         final String password = "thepassword";
@@ -219,6 +220,11 @@ public class DataSourceConfigManagerTest {
         properties.put(KEY_LOCAL_PROPERTY, VALUE_LOCAL_PROPERTY);
         properties.put(KEY_NONLOCAL_PROPERTY, "something");
 
+        // Exceptions local properties not being forwarded
+        final String VALUE_DATASOURCE_NAME = "myDataSource";
+        properties.put(KEY_DATASOURCE_TYPE, "DataSource");
+        properties.put(DataSourceFactory.JDBC_DATASOURCE_NAME, VALUE_DATASOURCE_NAME);
+
         Properties expectedDataSourceProperties = new Properties();
         expectedDataSourceProperties.put(DataSourceFactory.JDBC_DATABASE_NAME, dbname);
         expectedDataSourceProperties.put(DataSourceFactory.JDBC_USER, user);
@@ -230,6 +236,7 @@ public class DataSourceConfigManagerTest {
 
         Hashtable<String, String> expectedServiceProperties = (Hashtable<String, String>)properties.clone();
         expectedServiceProperties.remove(KEY_HIDDEN_JDBC_PASSWORD);
+        expectedServiceProperties.put("osgi.jndi.service.name", VALUE_DATASOURCE_NAME);
         ServiceRegistration sreg = c.createMock(ServiceRegistration.class);
         expect(context.registerService(anyString(), eq(ds), eq(expectedServiceProperties))).andReturn(sreg);
 


### PR DESCRIPTION
Fixes regression of [paxjdbc-85]: Do not forward key "dataSourceName"
even though it is a local key (not containing a dot).