### PR TITLE
[PAXJDBC-91] Add check for null

### DIFF
--- a/pax-jdbc-mssql/src/main/java/org/ops4j/pax/jdbc/mssql/impl/MSSQLDataSourceFactory.java
+++ b/pax-jdbc-mssql/src/main/java/org/ops4j/pax/jdbc/mssql/impl/MSSQLDataSourceFactory.java
@@ -113,8 +113,10 @@ public class MSSQLDataSourceFactory implements DataSourceFactory {
     }
     
     private void setIntProperty(String value, Object instance, String methodName) throws Exception {
-        int iValue = new Integer(value);
-        instance.getClass().getMethod(methodName, int.class).invoke(instance, iValue);
+        if (value != null) {
+            int iValue = new Integer(value);
+            instance.getClass().getMethod(methodName, int.class).invoke(instance, iValue);
+        }
     }
 
 }

--- a/pax-jdbc-mssql/src/test/java/org/ops4j/pax/jdbc/mssql/impl/MSSQLDataSourceFactoryTest.java
+++ b/pax-jdbc-mssql/src/test/java/org/ops4j/pax/jdbc/mssql/impl/MSSQLDataSourceFactoryTest.java
@@ -41,8 +41,6 @@ public class MSSQLDataSourceFactoryTest {
         SQLServerDataSource ds = (SQLServerDataSource)dsf.createDataSource(props);
         validateDS(ds);
     }
-
-
     
     @Test
     public void testConnectionPoolDS() throws SQLException, ClassNotFoundException {
@@ -68,6 +66,14 @@ public class MSSQLDataSourceFactoryTest {
         Assert.assertNotNull(driver);
     }
     
+    @Test
+    public void testEmptyProps() throws SQLException, ClassNotFoundException {
+        MSSQLDataSourceFactory dsf = new MSSQLDataSourceFactory();
+        Properties props = new Properties();
+        SQLServerDataSource ds = (SQLServerDataSource)dsf.createDataSource(props);
+        Assert.assertNotNull(ds);
+    }
+
     private void validateDS(SQLServerDataSource ds) {
         Assert.assertEquals(URL, ds.url);
         Assert.assertEquals(DB, ds.dbName);
@@ -87,4 +93,5 @@ public class MSSQLDataSourceFactoryTest {
         props.put("password", PASSWORD);
         return props;
     }
+
 }


### PR DESCRIPTION
In case the JDBC port is not given explicitly, a check for null is
necessary.