### PR TITLE
[PAXJDBC-109] Add pax-jdbc-jtds to Maven module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>pax-jdbc-mariadb</module>
         <module>pax-jdbc-oracle</module>
         <module>pax-jdbc-mssql</module>
+        <module>pax-jdbc-jtds</module>
         <module>pax-jdbc-config</module>
         <module>pax-jdbc-pool-dbcp2</module>
         <module>pax-jdbc-pool-hikaricp</module>


### PR DESCRIPTION
Unfortunately pax-jdbc-jtds was missing in the Maven modules of the parent.

Signed-off-by: Sascha Vogt <sascha@vogt-neuenbuerg.de>