### PR TITLE
add initial extension to support StringEncryptor aliases

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/Activator.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/Activator.java
@@ -18,24 +18,21 @@ package org.ops4j.pax.jdbc.config.impl;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import org.jasypt.encryption.StringEncryptor;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.ManagedServiceFactory;
-import org.osgi.util.tracker.ServiceTracker;
 
 public class Activator implements BundleActivator {
 
     private static final String FACTORY_PID = "org.ops4j.datasource";
-    private ServiceTracker encryptorServiceTracker;
+    private StringEncryptorTracker encryptorServiceTracker;
 
     @Override
     public void start(BundleContext context) throws Exception {
         Dictionary<String, String> props = new Hashtable<String, String>();
         props.put(Constants.SERVICE_PID, FACTORY_PID);
-
-        encryptorServiceTracker = new ServiceTracker(context, StringEncryptor.class.getName(), null);
+        encryptorServiceTracker = new StringEncryptorTracker(context);
         encryptorServiceTracker.open();
         Decryptor decryptor = new Decryptor(encryptorServiceTracker);
         DataSourceConfigManager configManager = new DataSourceConfigManager(context, decryptor);

--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/StringEncryptorTracker.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/StringEncryptorTracker.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.jdbc.config.impl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jasypt.encryption.StringEncryptor;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * StringEncryptor service tracker. It is a wrapper to get service for a given alias.
+ */
+public class StringEncryptorTracker extends ServiceTracker {
+
+    /**
+     * OSGi property key used for StringEncryptor aliases.
+     */
+    public static final String ALIAS_PROPERTY_KEY = "alias";
+
+    private static final Logger LOG = LoggerFactory.getLogger(StringEncryptorTracker.class);
+
+    private final transient Map<String, StringEncryptor> encryptors = Collections.synchronizedSortedMap(new TreeMap<String, StringEncryptor>());
+
+    static long ENCRYPTOR_SERVICE_TIMEOUT = 30000L;
+
+    /**
+     * Create new StringEncryptor service tracker instance.
+     *
+     * @param context OSGi bundle context
+     */
+    public StringEncryptorTracker(final BundleContext context) {
+        super(context, StringEncryptor.class.getName(), null);
+    }
+
+    /**
+     * Add a StringEncryptor service and store it for Decryptor too. Waiting threads are notified too for a given alias.
+     *
+     * @param reference OSGi service reference
+     * @return OSGi service
+     */
+    @Override
+    public Object addingService(final ServiceReference reference) {
+        final String key = getAlias(reference);
+        final StringEncryptor stringEncryptor = (StringEncryptor) super.addingService(reference);
+
+        encryptors.put(key, stringEncryptor);
+
+        final Object lockObject = LockObject.get(key);
+        synchronized (lockObject) {
+            lockObject.notify();
+        }
+
+        return stringEncryptor;
+    }
+
+    /**
+     * Modify a StringEncryptor service. Internal store is also updated because alias could be changed. Waiting threads
+     * are notified too for a given alias.
+     *
+     * @param reference OSGi service reference
+     * @param service OSGi service
+     */
+    @Override
+    public void modifiedService(final ServiceReference reference, Object service) {
+        final String key = getAlias(reference);
+
+        final StringEncryptor stringEncryptor = (StringEncryptor) service;
+
+        for (Iterator<Map.Entry<String, StringEncryptor>> it = encryptors.entrySet().iterator(); it.hasNext();) {
+            final Map.Entry<String, StringEncryptor> entry = it.next();
+            if (service.equals(entry.getValue())) {
+                it.remove();
+            }
+        }
+
+        encryptors.put(key, stringEncryptor);
+
+        final Object lockObject = LockObject.get(key);
+        synchronized (lockObject) {
+            lockObject.notify();
+        }
+
+        super.modifiedService(reference, service);
+    }
+
+    /**
+     * Remove a StringEncryptor service.
+     *
+     * @param reference OSGi service reference
+     * @param service OSGi service
+     */
+    @Override
+    public void removedService(final ServiceReference reference, Object service) {
+        final String key = getAlias(reference);
+        encryptors.remove(key);
+
+        super.removedService(reference, service);
+    }
+
+    /**
+     * Get internal store key for the given service reference. Is it calculated based on OSGi service property (alias).
+     *
+     * @param reference OSGi service reference
+     * @return key for internal store
+     */
+    private String getAlias(final ServiceReference reference) {
+        final Object aliasProp = reference.getProperty(ALIAS_PROPERTY_KEY);
+        return getKey(aliasProp != null ? aliasProp.toString() : null);
+    }
+
+    /**
+     * Create internal store key for a given alias. 'X' character is used of null alias, 'A' prefix is added otherwise
+     * as internal store key.
+     *
+     * @param alias OSGi service property (alias)
+     * @return internal store key
+     */
+    private static String getKey(final String alias) {
+        return alias != null ? "A" + alias : "X";
+    }
+
+    /**
+     * Get StringEncryptor for a given alias. Thread is waiting for a specific time if service is not available yet.
+     *
+     * @param alias alias of the StringEncryptor (null value is supported too)
+     * @return StringEncryptor instance
+     */
+    public StringEncryptor getStringEncryptor(final String alias) {
+        final String key = getKey(alias);
+        StringEncryptor encryptor = encryptors.get(key);
+
+        if (encryptor == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Waiting for StringEncryptor with alias: " + alias);
+            }
+            final LockObject lockObject = LockObject.get(key);
+            synchronized (lockObject) {
+                try {
+                    lockObject.wait(ENCRYPTOR_SERVICE_TIMEOUT);
+                } catch (InterruptedException ex) {
+                    LOG.warn("Waiting for String encryptor service is interrupted, alias: " + alias);
+                }
+            }
+
+            // retry if notified/timed out
+            encryptor = encryptors.get(key);
+
+            if (encryptor == null) {
+                LOG.warn("StringEncryptor service it not available with alias: " + alias);
+            }
+        }
+
+        return encryptor;
+    }
+
+    /**
+     * Cleanup cached services.
+     */
+    @Override
+    public void close() {
+        super.close();
+        encryptors.clear();
+    }
+
+    /**
+     * Lock objects used to notify waiting threads for StringEncryptor with a specific alias.
+     */
+    private static class LockObject {
+
+        private static final Map<String, LockObject> LOCKS = new HashMap<>();
+
+        /**
+         * Get lock object for a given key (alias).
+         *
+         * @param key StringEncryptor key, null value is not supported
+         * @return lock object
+         */
+        static synchronized LockObject get(final String key) {
+            LockObject lock = LOCKS.get(key);
+            if (lock == null) {
+                lock = new LockObject();
+                LOCKS.put(key, lock);
+            }
+            return lock;
+        }
+    }
+}

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManagerTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isNull;
 import static org.easymock.EasyMock.matches;
 import static org.junit.Assert.assertEquals;
 
@@ -254,9 +255,10 @@ public class DataSourceConfigManagerTest {
         StringEncryptor encryptor = c.createMock(StringEncryptor.class);
         expect(encryptor.decrypt(matches("ciphertext"))).andReturn("plaintext");
 
-        ServiceTracker encryptorServiceTracker = c.createMock(ServiceTracker.class);
-        expect(encryptorServiceTracker.waitForService(anyInt())).andReturn(encryptor);
-        Decryptor decryptor = new Decryptor(encryptorServiceTracker);
+        StringEncryptorTracker tracker = c.createMock(StringEncryptorTracker.class);
+        EasyMock.expect(tracker.getStringEncryptor(EasyMock.isNull(String.class))).andReturn(encryptor);
+
+        Decryptor decryptor = new Decryptor(tracker);
         return decryptor;
     }
 }

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/StringEncryporTrackerTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/StringEncryporTrackerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.jdbc.config.impl;
+
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.util.text.BasicTextEncryptor;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+public class StringEncryporTrackerTest {
+
+    @Before
+    public void setup() {
+        StringEncryptorTracker.ENCRYPTOR_SERVICE_TIMEOUT = 100L;
+    }
+
+    @Test
+    public void testStringEncryptorWithAlias() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+
+        final String alias = "testAlias";
+
+        final StringEncryptor stringEncryptor = new TestStringEncryptor();
+
+        BundleContext context = c.createMock(BundleContext.class);
+        EasyMock.expect(context.getService(EasyMock.anyObject(ServiceReference.class))).andReturn(stringEncryptor);
+        EasyMock.expect(context.createFilter(EasyMock.anyString())).andReturn(c.createMock(Filter.class));
+
+        ServiceReference reference = c.createMock(ServiceReference.class);
+        EasyMock.expect(reference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias).atLeastOnce();
+
+        c.replay();
+
+        StringEncryptorTracker tracker = new StringEncryptorTracker(context);
+        tracker.addingService(reference);
+
+        final StringEncryptor availableStringEncryptor = tracker.getStringEncryptor(alias);
+
+        c.verify();
+
+        assertEquals(stringEncryptor, availableStringEncryptor);
+    }
+
+    @Test
+    public void testLazyStringEncryptor() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+
+        final String alias = "testAlias";
+
+        final StringEncryptor stringEncryptor = new TestStringEncryptor();
+
+        final BundleContext context = c.createMock(BundleContext.class);
+        EasyMock.expect(context.getService(EasyMock.anyObject(ServiceReference.class))).andReturn(stringEncryptor);
+        EasyMock.expect(context.createFilter(EasyMock.anyString())).andReturn(c.createMock(Filter.class));
+
+        final ServiceReference reference = c.createMock(ServiceReference.class);
+        EasyMock.expect(reference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias).atLeastOnce();
+
+        StringEncryptorTracker.ENCRYPTOR_SERVICE_TIMEOUT = 10000L;
+        final long waitingTime = 800L;
+
+        c.replay();
+
+        final StringEncryptorTracker tracker = new StringEncryptorTracker(context);
+
+        final long startTs = System.currentTimeMillis();
+        
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(waitingTime);
+                    tracker.addingService(reference);
+                } catch (InterruptedException ex) {
+                }
+            }
+        });
+        t.start();
+
+        final StringEncryptor availableStringEncryptor = tracker.getStringEncryptor(alias);
+        
+        final long endTs = System.currentTimeMillis();
+
+        c.verify();
+        
+        final long duration = endTs - startTs;
+        
+        // tolerance: delay of service + 100 ms + 10%, it should be less than timeout of the service tracker
+        Assert.assertTrue(duration < (waitingTime + 100) * 1.1);
+        
+        assertEquals(stringEncryptor, availableStringEncryptor);
+    }
+    
+    @Test
+    public void testReconfiguredStringEncryptor() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+
+        final String alias = "testAlias";
+        final String alias2 = "testAlias2";
+
+        final StringEncryptor stringEncryptor = new TestStringEncryptor();
+
+        final BundleContext context = c.createMock(BundleContext.class);
+        EasyMock.expect(context.getService(EasyMock.anyObject(ServiceReference.class))).andReturn(stringEncryptor);
+        EasyMock.expect(context.createFilter(EasyMock.anyString())).andReturn(c.createMock(Filter.class));
+
+        final ServiceReference originalReference = c.createMock(ServiceReference.class);
+        EasyMock.expect(originalReference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias).atLeastOnce();
+        
+        final ServiceReference modifiedReference = c.createMock(ServiceReference.class);
+        EasyMock.expect(modifiedReference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias2).atLeastOnce();
+
+        StringEncryptorTracker.ENCRYPTOR_SERVICE_TIMEOUT = 10000L;
+        final long waitingTime = 800L;
+
+        c.replay();
+
+        final StringEncryptorTracker tracker = new StringEncryptorTracker(context);
+        tracker.addingService(originalReference);
+
+        final long startTs = System.currentTimeMillis();
+        
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(waitingTime);
+                    tracker.modifiedService(modifiedReference, stringEncryptor);
+                } catch (InterruptedException ex) {
+                }
+            }
+        });
+        t.start();
+
+        final StringEncryptor availableStringEncryptor = tracker.getStringEncryptor(alias2);
+        
+        final long endTs = System.currentTimeMillis();
+
+        c.verify();
+        
+        final long duration = endTs - startTs;
+        
+        // tolerance: delay of service + 100 ms + 10%, it should be less than timeout of the service tracker
+        Assert.assertTrue(duration < (waitingTime + 100) * 1.1);
+        
+        assertEquals(stringEncryptor, availableStringEncryptor);
+    }
+
+    @Test
+    public void testStringEncryptorWithoutAlias() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+
+        final String alias = null;
+
+        final StringEncryptor stringEncryptor = new TestStringEncryptor();
+
+        BundleContext context = c.createMock(BundleContext.class);
+        EasyMock.expect(context.getService(EasyMock.anyObject(ServiceReference.class))).andReturn(stringEncryptor);
+        EasyMock.expect(context.createFilter(EasyMock.anyString())).andReturn(c.createMock(Filter.class));
+
+        ServiceReference reference = c.createMock(ServiceReference.class);
+        EasyMock.expect(reference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias).atLeastOnce();
+
+        c.replay();
+
+        StringEncryptorTracker tracker = new StringEncryptorTracker(context);
+        tracker.addingService(reference);
+
+        final StringEncryptor availableStringEncryptor = tracker.getStringEncryptor(alias);
+
+        c.verify();
+
+        assertEquals(stringEncryptor, availableStringEncryptor);
+    }
+
+    @Test
+    public void testMissingStringEncryptor() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+
+        final String alias = "testAlias";
+        final String alias2 = "testAlias2";
+
+        final StringEncryptor stringEncryptor = new TestStringEncryptor();
+
+        BundleContext context = c.createMock(BundleContext.class);
+        EasyMock.expect(context.getService(EasyMock.anyObject(ServiceReference.class))).andReturn(stringEncryptor);
+        EasyMock.expect(context.createFilter(EasyMock.anyString())).andReturn(c.createMock(Filter.class));
+
+        ServiceReference reference = c.createMock(ServiceReference.class);
+        EasyMock.expect(reference.getProperty(EasyMock.eq(StringEncryptorTracker.ALIAS_PROPERTY_KEY))).andReturn(alias).atLeastOnce();
+
+        c.replay();
+
+        StringEncryptorTracker tracker = new StringEncryptorTracker(context);
+        tracker.addingService(reference);
+
+        final StringEncryptor availableStringEncryptor = tracker.getStringEncryptor(alias2);
+
+        c.verify();
+
+        Assert.assertNull(availableStringEncryptor);
+    }
+
+    private static final class TestStringEncryptor implements StringEncryptor {
+
+        private final BasicTextEncryptor textEncryptor;
+
+        public TestStringEncryptor() {
+            textEncryptor = new BasicTextEncryptor();
+            textEncryptor.setPassword("myPassword");
+        }
+
+        @Override
+        public String decrypt(String cipherText) {
+
+            return textEncryptor.decrypt(cipherText);
+        }
+
+        @Override
+        public String encrypt(String decipherText) {
+            return textEncryptor.encrypt(decipherText);
+        }
+
+    }
+}


### PR DESCRIPTION
A custom ServiceTracker is added to Decryptor tracking StringEncryptor services that supports aliases too so selection is not based only on service ranking (if multiple instances exists). Extension is backward-compatible with previous solution, alias is optional.

You can set password in the following format for using StringEncryptor service with _alias=jdbc_ property:
`password=ENC(4wuiVQb/9AcPd6JeB9fatny/vMBZsdHq,jdbc)`