### PR TITLE
PAXJDBC-125 - allowed setting xa config as false. it now throws

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
@@ -149,11 +149,16 @@ public class DataSourceConfigManager implements ManagedServiceFactory {
         String xa = (String) config.remove(PooledDataSourceFactory.XA_KEY);
         if (xa == null) {
             return false;
+        } else {
+        	if ("true".equals(xa)) {
+        		return true;
+        	} else if ("false".equals(xa)) {
+        		return false;
+        	} else {
+        		throw new ConfigurationException(null, "Invalid XA configuration provided, XA can only be set to true or false");
+        	}
         }
-        if (!"true".equals(xa)) {
-            throw new ConfigurationException(null, "XA can only be set to true");
-        }
-        return true;
+        
     }
 
     private Filter getDSFFilter(Dictionary config) throws ConfigurationException, InvalidSyntaxException {


### PR DESCRIPTION
Allow setting xa=false in datasource config file. ConfigurationException is thrown if set to anything other than true or false.