### PR TITLE
PAXJDBC-126 upgraded HikariCP to 2.4.11 (java 7) 

### DIFF
--- a/pax-jdbc-features/src/main/resources/features.xml
+++ b/pax-jdbc-features/src/main/resources/features.xml
@@ -150,7 +150,7 @@
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${jta.bundle.version}</bundle>
         <bundle>mvn:org.ops4j.pax.jdbc/pax-jdbc-pool-common/${project.version}</bundle>
         <bundle>mvn:org.ops4j.pax.jdbc/pax-jdbc-pool-hikaricp/${project.version}</bundle>
-        <bundle>mvn:com.zaxxer/HikariCP/2.4.1</bundle>
+        <bundle>mvn:com.zaxxer/HikariCP-java7/${hikaricp.version}</bundle>
     </feature>
 
     <feature name="pax-jdbc-pool-aries" description="Provides JDBC Pooling DataSourceFactory using Aries Transaction JDBC"

--- a/pax-jdbc-itest/src/test/java/org/ops4j/pax/jdbc/test/pool/PoolHikaricpTest.java
+++ b/pax-jdbc-itest/src/test/java/org/ops4j/pax/jdbc/test/pool/PoolHikaricpTest.java
@@ -24,7 +24,7 @@ public class PoolHikaricpTest extends AbstractJdbcTest {
                 poolDefaults(), //
                 mvnBundle("commons-logging", "commons-logging"),
                 mvnBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.cglib"),
-                mvnBundle("com.zaxxer", "HikariCP"),
+                mvnBundle("com.zaxxer", "HikariCP-java7"),
                 mvnBundle("org.ops4j.pax.jdbc", "pax-jdbc-pool-hikaricp"),
                 };
     }

--- a/pax-jdbc-pool-hikaricp/pom.xml
+++ b/pax-jdbc-pool-hikaricp/pom.xml
@@ -22,8 +22,7 @@
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>2.4.1</version>
+            <artifactId>HikariCP-java7</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pax-jdbc-pool-hikaricp/src/test/java/org/ops4j/pax/jdbc/pool/hikaricp/impl/ds/HikariPooledDataSourceFactoryTest.java
+++ b/pax-jdbc-pool-hikaricp/src/test/java/org/ops4j/pax/jdbc/pool/hikaricp/impl/ds/HikariPooledDataSourceFactoryTest.java
@@ -61,7 +61,7 @@ public class HikariPooledDataSourceFactoryTest {
             pdsf.create(dataSourceFactory, createInvalidPoolConfig());
         } catch (RuntimeException e) {
             Assert.assertEquals(
-                    "java.beans.IntrospectionException: Method not found: setDummy",
+                    "Property dummy does not exist on target class com.zaxxer.hikari.HikariConfig",
                     e.getMessage());
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <postgresql.version>9.4.1212.jre7</postgresql.version>
         <slf4j.version>1.6.4</slf4j.version>
         <sqlite.version>3.16.1</sqlite.version>
+        <hikaricp.version>2.4.11</hikaricp.version>
     </properties>
 
     <scm>
@@ -314,6 +315,12 @@
                 <groupId>org.apache.servicemix.bundles</groupId>
                 <artifactId>org.apache.servicemix.bundles.c3p0</artifactId>
                 <version>${c3p0.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP-java7</artifactId>
+        	    <version>${hikaricp.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
upgraded HikariCP to 2.4.11 (java 7) and also declared the version of hikaricp as part of main pom.