### PR TITLE
Update mysql.version to latest: 5.1.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <junit.version>4.12</junit.version>
         <logback.version>1.0.9</logback.version>
         <mariadb.version>1.5.9</mariadb.version>
-        <mysql.version>5.1.34</mysql.version>
+        <mysql.version>5.1.43</mysql.version>
         <narayana.version>5.2.8.Final</narayana.version>
         <ops4j.base.version>1.5.0</ops4j.base.version>
         <pax.exam.version>4.10.0</pax.exam.version>


### PR DESCRIPTION
Build run locally: all success.  It appears that the build/test order requires the OPS4J Pax JDBC Pooling Support using C3P0 module to be built individually before running the full build(?).  Karaf feature verification step fails.

In my case this version update fixes a very strange issue with PreparedStatement.setTimestamp where some timestamp/date fields would inexplicably be null in the actual SQL sent to the database despite having set the value in code.

*May* be related to:
 
https://github.com/mysql/mysql-connector-j/commit/62dcf358e0783a013117303cf77b899cd64bd6c0