### PR TITLE
[pax-jdbc-pool-transx] Support for multiple  transx  datasources in the same instance

### DIFF
--- a/pax-jdbc-pool-transx/src/main/java/org/ops4j/pax/jdbc/pool/transx/impl/TransxPooledDataSourceFactory.java
+++ b/pax-jdbc-pool-transx/src/main/java/org/ops4j/pax/jdbc/pool/transx/impl/TransxPooledDataSourceFactory.java
@@ -40,11 +40,12 @@ public class TransxPooledDataSourceFactory implements PooledDataSourceFactory {
 
     private  static final Logger LOG = LoggerFactory.getLogger(TransxPooledDataSourceFactory.class);
     protected static final String POOL_PREFIX = "pool.";
-
+    protected static final String DS_USERNAME = "user";
     public DataSource create(DataSourceFactory dsf, Properties props) throws SQLException {
         try {
+            String name=props.getProperty(DS_USERNAME);
             CommonDataSource ds = dsf.createDataSource(getNonPoolProps(props));
-            DataSource mds = ManagedDataSourceBuilder.builder()
+            DataSource mds = ManagedDataSourceBuilder.builder().name(name)
                     .dataSource(ds)
                     .transaction(TransactionSupportLevel.NoTransaction)
                     .build();

--- a/pax-jdbc-pool-transx/src/main/java/org/ops4j/pax/jdbc/pool/transx/impl/TransxXaPooledDataSourceFactory.java
+++ b/pax-jdbc-pool-transx/src/main/java/org/ops4j/pax/jdbc/pool/transx/impl/TransxXaPooledDataSourceFactory.java
@@ -51,8 +51,9 @@ public class TransxXaPooledDataSourceFactory extends TransxPooledDataSourceFacto
     @Override
     public DataSource create(DataSourceFactory dsf, Properties props) throws SQLException {
         try {
+            String name=props.getProperty(DS_USERNAME);
             XADataSource ds = dsf.createXADataSource(getNonPoolProps(props));
-            DataSource mds = ManagedDataSourceBuilder.builder()
+            DataSource mds = ManagedDataSourceBuilder.builder().name(name)
                     .dataSource(ds)
                     .transaction(TransactionSupportLevel.XATransaction)
                     .transactionManager(tm)


### PR DESCRIPTION
If you have multiple datasources in a single karaf instance  there is an error:  
"Attempt to register second resource with name **XADataSourceMCF**"  because  the DatasourceBulder don't register a name for each datasource.

```
2017-08-23T09:06:57,458 | ERROR | features-1-thread-1 | TransxXaPooledDataSourceFactory  | 101 - org.ops4j.pax.jdbc.pool.transx - 1.2.0.SNAPSHOT | Error creating pooled datasourceAttempt to register second resource with name XADataSourceMCF
java.lang.IllegalStateException: Attempt to register second resource with name XADataSourceMCF
```

