### PR TITLE
Fix ConcurrentModificationException in DataSourceConfigManager.destroy() when 2 or more configs managed

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/DataSourceConfigManager.java
@@ -192,7 +192,7 @@ public class DataSourceConfigManager implements ManagedServiceFactory {
     }
 
     synchronized void destroy() {
-        for (String pid : trackers.keySet()) {
+        for (String pid : trackers.keySet().toArray(new String[0])) {
             deleted(pid);
         }
     }


### PR DESCRIPTION
Test included