### PR TITLE
[PAXJDBC-147] Fix handling of external configLoader for false friends

### DIFF
--- a/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/ExternalConfigLoader.java
+++ b/pax-jdbc-config/src/main/java/org/ops4j/pax/jdbc/config/impl/ExternalConfigLoader.java
@@ -71,7 +71,17 @@ public class ExternalConfigLoader {
             if (config.get(key) instanceof String && isExternal(value)) {
                 Matcher matcher = CONFIG_LOADER_PATTERN.matcher(value);
                 matcher.matches();
-                String loadedValue = "ENC".equals(matcher.group(1)) ? value : configLoaders.get(matcher.group(1)).resolve(matcher.group(2));
+                String loadedValue = null;
+                if ("ENC".equals(matcher.group(1))) {
+                    loadedValue = value;
+                } else {
+                    ConfigLoader configLoader = configLoaders.get(matcher.group(1));
+                    if (configLoader != null) {
+                        loadedValue = configLoader.resolve(matcher.group(2));
+                    } else {
+                        loadedValue = value;
+                    }
+                }
                 if (loadedValue != null) {
                     loadedConfig.put(key, loadedValue);
                 }

--- a/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/ExternalConfigLoaderTest.java
+++ b/pax-jdbc-config/src/test/java/org/ops4j/pax/jdbc/config/impl/ExternalConfigLoaderTest.java
@@ -119,6 +119,21 @@ public class ExternalConfigLoaderTest {
         assertEquals(2000, loaded.get("timeout"));
     }
 
+    @Test
+    public void testCrazyExternalConfig() {
+        Dictionary<String, Object> cfProps = new Hashtable<>();
+        cfProps.put("name", "testCF");
+        cfProps.put("url", "jdbc:oracle:thin:@(DESCRIPTION_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=dummy)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=XE))))");
+        cfProps.put("timeout", 2000);
+
+        final ExternalConfigLoader externalConfigLoader = new ExternalConfigLoader(context);
+        Dictionary<String, Object> loaded = externalConfigLoader.resolve(cfProps);
+
+        assertEquals("testCF", loaded.get("name"));
+        assertEquals("jdbc:oracle:thin:@(DESCRIPTION_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=dummy)(PORT=1521)))(CONNECT_DATA=(INSTANCE_NAME=XE))))", loaded.get("url"));
+        assertEquals(2000, loaded.get("timeout"));
+    }
+
     public static String createExternalSecret(final String value) {
         try {
             final File file = File.createTempFile("externalPaxJdbcConfig-", ".secret");


### PR DESCRIPTION
@grgrzybek : Just added fallback if no external config loader is found. This will workaround if config looks like external reference. What do you think?

Another way is the need to escape brackets. This might need a change in Karaf, too.