### PR TITLE
[PAXJDBC-228] - NPE when creating HSQLDB datasource without a username

### DIFF
--- a/pax-jdbc-hsqldb/src/main/java/org/ops4j/pax/jdbc/hsqldb/impl/HsqldbDataSourceFactory.java
+++ b/pax-jdbc-hsqldb/src/main/java/org/ops4j/pax/jdbc/hsqldb/impl/HsqldbDataSourceFactory.java
@@ -61,8 +61,10 @@ public class HsqldbDataSourceFactory implements DataSourceFactory {
             ds.setPassword(password);
         }
 
-        String user = (String) props.remove(DataSourceFactory.JDBC_USER);
-        ds.setUser(user);
+        if (props.containsKey(DataSourceFactory.JDBC_USER)) {
+          String user = (String) props.remove(DataSourceFactory.JDBC_USER);
+          ds.setUser(user);
+        }
 
         if (!props.isEmpty()) {
             BeanConfig.configure(ds, props);

--- a/pax-jdbc-hsqldb/src/test/java/org/ops4j/pax/jdbc/hsqldb/impl/TestDsf.java
+++ b/pax-jdbc-hsqldb/src/test/java/org/ops4j/pax/jdbc/hsqldb/impl/TestDsf.java
@@ -42,6 +42,27 @@ public class TestDsf {
         try (Connection con = ds.getConnection()) {
             DatabaseMetaData md = con.getMetaData();
             LOG.info("DB: {}/{}", md.getDatabaseProductName(), md.getDatabaseProductVersion());
+            LOG.info("Username: {}", md.getUserName());
+            try (Statement st = con.createStatement()) {
+                try (ResultSet rs = st.executeQuery("select SCHEMA_NAME, SCHEMA_OWNER from INFORMATION_SCHEMA.SCHEMATA")) {
+                    while (rs.next()) {
+                        LOG.info("Schema: {}, owner: {}", rs.getString(1), rs.getString(2));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testPropertyBasedNoJddbcUser() throws ClassNotFoundException, SQLException {
+        DataSourceFactory factory = new HsqldbDataSourceFactory();
+        Properties props = new Properties();
+        props.setProperty(DataSourceFactory.JDBC_URL, "jdbc:hsqldb:mem:.");
+        DataSource ds = factory.createDataSource(props);
+        try (Connection con = ds.getConnection()) {
+            DatabaseMetaData md = con.getMetaData();
+            LOG.info("DB: {}/{}", md.getDatabaseProductName(), md.getDatabaseProductVersion());
+            LOG.info("Username: {}", md.getUserName());
 
             try (Statement st = con.createStatement()) {
                 try (ResultSet rs = st.executeQuery("select SCHEMA_NAME, SCHEMA_OWNER from INFORMATION_SCHEMA.SCHEMATA")) {
@@ -52,5 +73,6 @@ public class TestDsf {
             }
         }
     }
+
 
 }


### PR DESCRIPTION
- Verified JDBC_USER property exists before calling setUserName()
- Added test to verify datasource creation without JDBC_USER property
- Add LOG message with username for the new and existing test