### PR TITLE
Bump postgresql to 42.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>
         <version.org.hsqldb>2.7.2</version.org.hsqldb>
         <version.org.mariadb.jdbc>3.1.4</version.org.mariadb.jdbc>
-        <version.org.postgresql>42.6.0</version.org.postgresql>
+        <version.org.postgresql>42.6.2</version.org.postgresql>
         <version.org.xerial.sqlite>3.42.0.0</version.org.xerial.sqlite>
     </properties>
 


### PR DESCRIPTION
Bump PostgreSQL from version 42.6.0 -> 42.6.2, resolves critical vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2024-1597

Release notes:
https://jdbc.postgresql.org/changelogs/2024-02-21-42.6.1-release/
https://jdbc.postgresql.org/changelogs/2024-03-13-42.6.2-release/