### PR TITLE
Bump mysql-connector-j to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,8 +204,8 @@
         <!-- 12.2.0.jre8 has non-optional import for jdk.net package -->
         <version.com.microsoft.sqlserver.jdbc>12.3.1.jre8-preview</version.com.microsoft.sqlserver.jdbc>
         <version.com.oracle.database.jdbc>23.2.0.0</version.com.oracle.database.jdbc>
-        <!-- see https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-upgrading-to-8.0.html -->
-        <version.com.mysql>8.1.0</version.com.mysql>
+        <!-- see https://dev.mysql.com/doc/connector-j/en/connector-j-upgrading-to-8.0.html -->
+        <version.com.mysql>8.3.0</version.com.mysql>
         <version.net.sourceforge.jtds>1.3.1</version.net.sourceforge.jtds>
         <!-- 10.15.x is for JDK11+ -->
         <version.org.apache.derby>10.14.2.0</version.org.apache.derby>


### PR DESCRIPTION
Bump mysql-connector-j from version 8.1.0 to 8.3.0, resolves high vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2024-1597

Release notes:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-2-0.html
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-3-0.html